### PR TITLE
fix for materialize button session variable

### DIFF
--- a/packages/materialize/package.js
+++ b/packages/materialize/package.js
@@ -60,6 +60,7 @@ Package.onUse(function(api) {
     'views/collections/update.html',
     'views/collections/update.js',
     'views/collections/delete.html',
+	'views/collections/buttons.js',
     'views/pages/index.html',
     'views/pages/create.html',
     'views/pages/delete.html',

--- a/packages/materialize/views/collections/buttons.js
+++ b/packages/materialize/views/collections/buttons.js
@@ -1,3 +1,3 @@
-Template.materializeButtons.onRendered(function() {
+ReactiveTemplates.onRendered('materializeButtons', function() {
   Session.set("scorpius_autoformLoading", undefined);
 });


### PR DESCRIPTION
Fixes and implements this fix: https://github.com/sean-stanley/orion/commit/256e91bc39b96ec75cbbdf976d2deb0c2060cefc

It wasn't implemented correctly (should have used `ReactiveTemplates.onRendered`), and wasn't included in package.js

Thanks!